### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: crates/tuntun-node-napi


### PR DESCRIPTION
Potential fix for [https://github.com/orielhaim/TunTun/security/code-scanning/3](https://github.com/orielhaim/TunTun/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/sdk.yml` so all jobs default to least privilege. The best non-breaking fix is:

- Add at workflow root (e.g., after `concurrency` and before `defaults`):
  - `permissions:`
  - `  contents: read`

This sets a safe default for `lint`, `build`, and `test` without changing existing functionality. Keep the existing `publish` job-level permissions (`contents: read`, `id-token: write`) unchanged; job-level permissions override/extend as needed for publishing.

No imports, methods, or dependencies are needed (YAML-only config change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
