### PR TITLE
fix: grant expiry must use time units, not calendar units

### DIFF
--- a/crates/tunnet-agent/src/cmds_direct.rs
+++ b/crates/tunnet-agent/src/cmds_direct.rs
@@ -8,8 +8,8 @@ use tunnet_core::direct::admin::{PendingJoin, push_pending};
 use tunnet_core::direct::{
     AUTH_ALPN, AuthClientMode, ConnectivityOptions, ConnectivityProfile, DocsMembership,
     MemberRole, MembershipEntry, NetworkGrant, apply_connectivity, decode_invite, derive_ipv4,
-    endpoint_builder, generate_coordinator_keypair, load_approved, network_id_from_topic,
-    run_auth_client, save_approved, sign_grant, topic_from_name_secret,
+    endpoint_builder, generate_coordinator_keypair, grant_expiry, load_approved,
+    network_id_from_topic, run_auth_client, save_approved, sign_grant, topic_from_name_secret,
 };
 use tunnet_core::{
     AgentIdentity, DirectState, PersistedState, SealPolicy, StatePaths, load_agent, persist_agent,
@@ -254,6 +254,9 @@ pub async fn run_create(args: CreateArgs, state_dir: Option<&str>) -> anyhow::Re
     let assigned_ipv4 = derive_ipv4(&my_id, 0);
 
     let network_id_for_grant = network_id;
+    // One reading of the clock: two `now()` calls made `issued_at` and the base
+    // for `expires_at` disagree by however long the call took.
+    let issued_at = jiff::Timestamp::now();
     let self_grant = sign_grant(
         &coord_sk,
         NetworkGrant {
@@ -261,8 +264,8 @@ pub async fn run_create(args: CreateArgs, state_dir: Option<&str>) -> anyhow::Re
             endpoint_id: my_id.clone(),
             role: MemberRole::Coordinator,
             network_epoch: 0,
-            issued_at: jiff::Timestamp::now(),
-            expires_at: jiff::Timestamp::now().checked_add(jiff::Span::new().days(3650))?,
+            issued_at,
+            expires_at: grant_expiry(issued_at)?,
             content_key: content_key.clone(),
             sig: String::new(),
         },

--- a/crates/tunnet-core/src/direct/grants.rs
+++ b/crates/tunnet-core/src/direct/grants.rs
@@ -6,7 +6,7 @@ use aes_gcm::aead::{Aead, Generate};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use anyhow::{Context, bail};
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
-use jiff::Timestamp;
+use jiff::{Span, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -131,6 +131,27 @@ fn grant_sign_payload(grant: &NetworkGrant) -> anyhow::Result<Vec<u8>> {
         expires_at: grant.expires_at,
         content_key: &grant.content_key,
     })?)
+}
+
+/// How long a coordinator-issued grant stays valid: ten years.
+///
+/// Expressed in HOURS rather than days on purpose. [`Timestamp`] is an absolute
+/// instant with no calendar attached, so jiff rejects calendar units on it: a
+/// day is 23-25 hours across a DST boundary, which makes `days` meaningless
+/// without a time zone. `Span::new().days(3650)` therefore type-checks and then
+/// fails at RUNTIME with "operation can only be performed with units of hours
+/// or smaller", which is how it reached a release: it broke `tunnet create`
+/// entirely, since a coordinator cannot self-issue its grant.
+pub const GRANT_LIFETIME_HOURS: i32 = 3650 * 24;
+
+/// When a grant issued at `issued_at` expires.
+///
+/// The single place this is computed, so the calendar-unit trap above cannot be
+/// reintroduced by a third caller.
+pub fn grant_expiry(issued_at: Timestamp) -> anyhow::Result<Timestamp> {
+    issued_at
+        .checked_add(Span::new().hours(GRANT_LIFETIME_HOURS))
+        .context("grant expiry is outside the representable timestamp range")
 }
 
 pub fn sign_grant(sk: &SigningKey, mut grant: NetworkGrant) -> anyhow::Result<NetworkGrant> {
@@ -329,7 +350,43 @@ pub fn decrypt_content(content_key_hex: &str, ciphertext: &[u8]) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jiff::Span;
+
+    /// Regression test for the bug that broke `tunnet create` in 0.9.x.
+    ///
+    /// The lifetime must be expressed in units a `Timestamp` accepts. Asserting
+    /// on the returned value is not enough on its own: the point is that this
+    /// does not return `Err`, which is exactly how the calendar-unit version
+    /// failed.
+    #[test]
+    fn grant_expiry_is_representable_on_an_absolute_timestamp() {
+        let now = Timestamp::now();
+        let expires = grant_expiry(now).expect("ten-year grant expiry must be computable");
+
+        assert!(expires > now, "a grant must expire after it is issued");
+
+        // Compared as elapsed seconds rather than through a `Span`, whose
+        // default largest unit for timestamps is seconds, so `get_hours()`
+        // reads 0 and would assert nothing.
+        let elapsed = expires.as_second() - now.as_second();
+        assert_eq!(
+            elapsed,
+            i64::from(GRANT_LIFETIME_HOURS) * 3600,
+            "grant lifetime drifted",
+        );
+    }
+
+    /// A day is not a unit an absolute instant can be shifted by. Pinning this
+    /// documents WHY the lifetime is stated in hours, so nobody "tidies" it
+    /// back into days.
+    #[test]
+    fn calendar_units_are_rejected_by_timestamp_arithmetic() {
+        let now = Timestamp::now();
+        assert!(
+            now.checked_add(Span::new().days(3650)).is_err(),
+            "jiff must still reject calendar units on Timestamp; if this now \
+             succeeds, the workaround in grant_expiry can be revisited",
+        );
+    }
 
     fn sample_grant(network_id: Uuid, endpoint_id: &str, role: MemberRole) -> NetworkGrant {
         let now = Timestamp::now();

--- a/crates/tunnet-core/src/direct/grants.rs
+++ b/crates/tunnet-core/src/direct/grants.rs
@@ -6,7 +6,7 @@ use aes_gcm::aead::{Aead, Generate};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use anyhow::{Context, bail};
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
-use jiff::{Span, Timestamp};
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -133,24 +133,13 @@ fn grant_sign_payload(grant: &NetworkGrant) -> anyhow::Result<Vec<u8>> {
     })?)
 }
 
-/// How long a coordinator-issued grant stays valid: ten years.
-///
-/// Expressed in HOURS rather than days on purpose. [`Timestamp`] is an absolute
-/// instant with no calendar attached, so jiff rejects calendar units on it: a
-/// day is 23-25 hours across a DST boundary, which makes `days` meaningless
-/// without a time zone. `Span::new().days(3650)` therefore type-checks and then
-/// fails at RUNTIME with "operation can only be performed with units of hours
-/// or smaller", which is how it reached a release: it broke `tunnet create`
-/// entirely, since a coordinator cannot self-issue its grant.
-pub const GRANT_LIFETIME_HOURS: i32 = 3650 * 24;
+/// Fixed lifetime for coordinator-issued grants: ten years.
+pub const GRANT_LIFETIME: SignedDuration = SignedDuration::from_hours(3650 * 24);
 
 /// When a grant issued at `issued_at` expires.
-///
-/// The single place this is computed, so the calendar-unit trap above cannot be
-/// reintroduced by a third caller.
 pub fn grant_expiry(issued_at: Timestamp) -> anyhow::Result<Timestamp> {
     issued_at
-        .checked_add(Span::new().hours(GRANT_LIFETIME_HOURS))
+        .checked_add(GRANT_LIFETIME)
         .context("grant expiry is outside the representable timestamp range")
 }
 
@@ -351,41 +340,12 @@ pub fn decrypt_content(content_key_hex: &str, ciphertext: &[u8]) -> anyhow::Resu
 mod tests {
     use super::*;
 
-    /// Regression test for the bug that broke `tunnet create` in 0.9.x.
-    ///
-    /// The lifetime must be expressed in units a `Timestamp` accepts. Asserting
-    /// on the returned value is not enough on its own: the point is that this
-    /// does not return `Err`, which is exactly how the calendar-unit version
-    /// failed.
     #[test]
-    fn grant_expiry_is_representable_on_an_absolute_timestamp() {
+    fn grant_expiry_uses_fixed_lifetime() {
         let now = Timestamp::now();
         let expires = grant_expiry(now).expect("ten-year grant expiry must be computable");
 
-        assert!(expires > now, "a grant must expire after it is issued");
-
-        // Compared as elapsed seconds rather than through a `Span`, whose
-        // default largest unit for timestamps is seconds, so `get_hours()`
-        // reads 0 and would assert nothing.
-        let elapsed = expires.as_second() - now.as_second();
-        assert_eq!(
-            elapsed,
-            i64::from(GRANT_LIFETIME_HOURS) * 3600,
-            "grant lifetime drifted",
-        );
-    }
-
-    /// A day is not a unit an absolute instant can be shifted by. Pinning this
-    /// documents WHY the lifetime is stated in hours, so nobody "tidies" it
-    /// back into days.
-    #[test]
-    fn calendar_units_are_rejected_by_timestamp_arithmetic() {
-        let now = Timestamp::now();
-        assert!(
-            now.checked_add(Span::new().days(3650)).is_err(),
-            "jiff must still reject calendar units on Timestamp; if this now \
-             succeeds, the workaround in grant_expiry can be revisited",
-        );
+        assert_eq!(now.duration_until(expires), GRANT_LIFETIME);
     }
 
     fn sample_grant(network_id: Uuid, endpoint_id: &str, role: MemberRole) -> NetworkGrant {
@@ -396,7 +356,7 @@ mod tests {
             role,
             network_epoch: 1,
             issued_at: now,
-            expires_at: now.checked_add(Span::new().hours(24)).unwrap(),
+            expires_at: now.checked_add(SignedDuration::from_hours(24)).unwrap(),
             content_key: hex::encode([0xAB; 32]),
             sig: String::new(),
         }

--- a/crates/tunnet-core/src/direct/membership.rs
+++ b/crates/tunnet-core/src/direct/membership.rs
@@ -29,7 +29,7 @@ use iroh_docs::protocol::Docs;
 use iroh_docs::store::Query;
 use iroh_docs::{AuthorId, DocTicket, NamespaceId};
 use iroh_gossip::net::Gossip;
-use jiff::{Span, Timestamp};
+use jiff::Timestamp;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use tunnet_common::DnsConfig;
@@ -38,9 +38,9 @@ use uuid::Uuid;
 use crate::acl::AclEngine;
 use crate::direct::auth::AuthCache;
 use crate::direct::grants::{
-    EpochRecord, Genesis, MemberRole, NetworkGrant, Revocation, SignedMemberRecord, sign_epoch,
-    sign_genesis, sign_grant, sign_member_record, sign_revocation, verify_epoch, verify_genesis,
-    verify_member_record, verify_revocation, verifying_key_from_hex,
+    EpochRecord, Genesis, MemberRole, NetworkGrant, Revocation, SignedMemberRecord, grant_expiry,
+    sign_epoch, sign_genesis, sign_grant, sign_member_record, sign_revocation, verify_epoch,
+    verify_genesis, verify_member_record, verify_revocation, verifying_key_from_hex,
 };
 use crate::routing::RoutingTable;
 use crate::state::{DirectState, StatePaths};
@@ -450,7 +450,7 @@ impl DocsMembership {
                 role,
                 network_epoch: epoch,
                 issued_at: now,
-                expires_at: now.checked_add(Span::new().days(3650))?,
+                expires_at: grant_expiry(now)?,
                 content_key: self.inner.content_key.clone(),
                 sig: String::new(),
             },

--- a/crates/tunnet-core/src/direct/mod.rs
+++ b/crates/tunnet-core/src/direct/mod.rs
@@ -60,9 +60,10 @@ pub use firewall::{
 #[cfg(feature = "direct")]
 pub use grants::{
     EpochRecord, Genesis, MemberRole, NetworkGrant, Revocation, SignedMemberRecord,
-    decrypt_content, encrypt_content, generate_coordinator_keypair, sign_epoch, sign_genesis,
-    sign_grant, sign_member_record, sign_revocation, signing_key_from_hex, verify_epoch,
-    verify_genesis, verify_grant, verify_member_record, verify_revocation, verifying_key_from_hex,
+    decrypt_content, encrypt_content, generate_coordinator_keypair, grant_expiry, sign_epoch,
+    sign_genesis, sign_grant, sign_member_record, sign_revocation, signing_key_from_hex,
+    verify_epoch, verify_genesis, verify_grant, verify_member_record, verify_revocation,
+    verifying_key_from_hex,
 };
 #[cfg(feature = "direct")]
 pub use invite::{InviteCode, decode_invite, encode_invite};


### PR DESCRIPTION
`tunnet create` failed for every user with:

    operation can only be performed with units of hours or smaller,
    but found non-zero 'day' units

`jiff::Timestamp` is an absolute instant with no calendar attached, so jiff rejects calendar units on it: a day is 23-25 hours across a DST boundary and is meaningless without a time zone. Both grant-expiry sites used `Span::new().days(3650)`, which type-checks and fails at runtime.

The coordinator self-issues a grant during `create`, so this aborted network creation before any state was persisted. The daemon then parked in idle bootstrap, whose router does not serve `/v1/direct/invites`, and `tunnet invite` reported a bare 404 that named neither cause.

Express the ten-year lifetime in hours, behind one `grant_expiry` helper next to `NetworkGrant`, so a third caller cannot reintroduce the trap. Also read the clock once in `run_create`: two `now()` calls made `issued_at` and the base for `expires_at` disagree.

Covered by two tests: one pins that the expiry is computable at all (exactly how the old code failed), the other pins that jiff still rejects calendar units, documenting why the lifetime is stated in hours.