### PR TITLE
[DOCS] Change dash preview command to dash dev

### DIFF
--- a/apps/docs/self-hosting/index.md
+++ b/apps/docs/self-hosting/index.md
@@ -30,7 +30,7 @@ bun run db:migrate
 ./target/release/tunnet-control &
 bun run management:start &
 bun run dash:build &
-bun run dash:preview &
+bun run dash:dev &
 ```
 
 See the following pages for detailed configuration of each component.


### PR DESCRIPTION
As far as I can see preview no longer exists and fails, as it now is renamed to dev:
https://github.com/cocoon/Tunnet/blob/a1c92a36654cd9c0b4cf70b629143396e507b6ec/package.json#L12