### PR TITLE
chore(deps): upgrade osdns to 0.2.0 and clear pre-upgrade journal state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,7 +3653,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3875,10 +3875,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
- "futures-util",
  "inotify-sys",
  "libc",
- "tokio",
 ]
 
 [[package]]
@@ -3964,7 +3962,7 @@ checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2 0.6.5",
  "widestring",
- "windows-registry",
+ "windows-registry 0.6.1",
  "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
@@ -6410,15 +6408,18 @@ dependencies = [
 
 [[package]]
 name = "osdns"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527d6bdce06a6ade96927aa1bf816d40c584701ee503194fd6e3b4032007df7"
+checksum = "35b5d3839f1ab9af4fcbb53f76c2b74714c91415c1e27f9fff482b6e982cf1cb"
 dependencies = [
  "atomic-write-file",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "idna",
  "inotify",
+ "netlink-packet-core 0.9.0",
+ "netlink-packet-route 0.33.0",
+ "netlink-sys 0.9.0",
  "notify",
  "resolv-conf",
  "serde",
@@ -6427,8 +6428,9 @@ dependencies = [
  "thiserror 2.0.20",
  "tracing",
  "uuid",
- "windows 0.62.2",
- "windows-registry",
+ "windows-link 0.100.0",
+ "windows-registry 0.100.0",
+ "windows-result 0.100.0",
  "zbus",
 ]
 
@@ -11979,6 +11981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-link"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b39de7c7fe78858b0144c50c3fc000bab3be17d5e9b85b1053871693c7f7415"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12010,6 +12018,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b75dbbc0f2bb1ebbf6dcb6dc0035ae17f10ec280045d10fa27ad8874903b2"
+dependencies = [
+ "windows-link 0.100.0",
+ "windows-result 0.100.0",
+ "windows-strings 0.100.0",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12025,6 +12044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44873a1ef61c85d5e2991db91fe656cfcf0731097e00dff1ac860f1cb3b752a0"
+dependencies = [
+ "windows-link 0.100.0",
 ]
 
 [[package]]
@@ -12054,6 +12082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a70b590c684f1d2854f74999896f7c0558f1bdde62f599088599e20ea1d2f60"
+dependencies = [
+ "windows-link 0.100.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ jiff = { version = "0.2", features = ["serde"] }
 ipnet = { version = "2", features = ["serde"] }
 ipnetwork = { version = "0.21", features = ["serde"] }
 netdev = { version = "0.46", default-features = false, features = ["gateway"] }
-osdns = { version = "0.1.3", features = ["tracing"] }
+osdns = { version = "0.2.0", features = ["tracing"] }
 prefix-trie = "0.10"
 hickory-proto = "0.26"
 hickory-resolver = { version = "0.26", default-features = false, features = [

--- a/crates/tunnet-agent/src/system_dns.rs
+++ b/crates/tunnet-agent/src/system_dns.rs
@@ -307,35 +307,124 @@ pub fn desired_config(
 /// Never guesses ownership: external conflicts are surfaced and left
 /// untouched rather than blindly restoring old DNS state. Corrupt journals
 /// fail closed.
+/// Upper bound on pre-upgrade journal records discarded in one startup. Each
+/// clear removes exactly one named file, so the loop always terminates; the
+/// bound only stops an unbounded retry if removal silently fails to make
+/// progress.
+const MAX_LEGACY_JOURNAL_CLEARS: usize = 64;
+
 fn recover_stale(manager: &DnsManager) -> osdns::Result<()> {
-    match manager.recover_stale() {
-        Ok(outcomes) => {
-            for outcome in outcomes {
-                match outcome {
-                    RecoveryOutcome::Restored { resource, lease_id } => {
-                        tracing::info!(?resource, %lease_id, "recovered stale DNS transaction")
-                    }
-                    RecoveryOutcome::JournalCleared { resource, lease_id } => {
-                        tracing::info!(?resource, %lease_id, "cleared stale DNS journal")
-                    }
-                    RecoveryOutcome::ExternalConflict { resource, lease_id } => {
-                        tracing::error!(
-                            ?resource,
-                            %lease_id,
-                            "stale DNS transaction conflicts with external state; left untouched"
-                        )
-                    }
-                    RecoveryOutcome::Busy { resource } => {
-                        tracing::warn!(?resource, "stale DNS resource busy; left untouched")
-                    }
-                    _ => tracing::debug!("unrecognized DNS recovery outcome"),
-                }
+    for _ in 0..MAX_LEGACY_JOURNAL_CLEARS {
+        let error = match manager.recover_stale() {
+            Ok(outcomes) => {
+                report_recovery_outcomes(outcomes);
+                return Ok(());
             }
-            Ok(())
+            Err(e) => e,
+        };
+
+        // osdns 0.2 deliberately does not migrate 0.1.x journal records, and a
+        // single leftover record fails `recover_stale`, `abandon_journal` and
+        // `apply` alike, so DNS integration stays dead until the file is gone.
+        // The machines carrying such records are exactly the ones that crashed
+        // before the upgrade, so clearing them is the agent's job. osdns names
+        // the offending file, so remove precisely that record rather than
+        // wiping a state directory we do not own.
+        let legacy = match &error {
+            osdns::Error::UnsupportedJournalVersion {
+                path,
+                found,
+                supported,
+            } => Some((path.clone(), *found, *supported)),
+            _ => None,
+        };
+        let Some((path, found, supported)) = legacy else {
+            tracing::error!(error = %error, "DNS journal recovery failed; failing closed");
+            return Err(error);
+        };
+
+        tracing::warn!(
+            path = %path.display(),
+            found,
+            supported,
+            "discarding a pre-upgrade osdns journal record; 0.1.x DNS state is not migrated \
+             and any DNS settings it described are not restored"
+        );
+        if let Err(io) = std::fs::remove_file(&path) {
+            tracing::error!(
+                path = %path.display(),
+                error = %io,
+                "could not remove the pre-upgrade DNS journal record; failing closed"
+            );
+            return Err(error);
         }
-        Err(e) => {
-            tracing::error!(error = %e, "DNS journal recovery failed; failing closed");
-            Err(e)
+    }
+
+    tracing::error!(
+        limit = MAX_LEGACY_JOURNAL_CLEARS,
+        "gave up clearing pre-upgrade DNS journal records; failing closed"
+    );
+    report_recovery_outcomes(manager.recover_stale()?);
+    Ok(())
+}
+
+fn report_recovery_outcomes(outcomes: Vec<RecoveryOutcome>) {
+    for outcome in outcomes {
+        match outcome {
+            RecoveryOutcome::Restored { resource, lease_id } => {
+                tracing::info!(?resource, %lease_id, "recovered stale DNS transaction")
+            }
+            RecoveryOutcome::JournalCleared { resource, lease_id } => {
+                tracing::info!(?resource, %lease_id, "cleared stale DNS journal")
+            }
+            RecoveryOutcome::Gone { resource, lease_id } => {
+                tracing::info!(
+                    ?resource,
+                    %lease_id,
+                    "DNS resource no longer exists; stale journal record cleared"
+                )
+            }
+            RecoveryOutcome::Replaced { resource, lease_id } => {
+                tracing::info!(
+                    ?resource,
+                    %lease_id,
+                    "DNS resource now names a different incarnation; nothing restored"
+                )
+            }
+            RecoveryOutcome::IdentityMismatch { resource, lease_id } => {
+                tracing::warn!(
+                    ?resource,
+                    %lease_id,
+                    "DNS resource identity could not be proven; left untouched for a later pass"
+                )
+            }
+            // Since osdns 0.2 a per-record failure is an outcome rather than an
+            // Err, so recovery as a whole reports success. Logging this at
+            // anything less than error would hide failures the previous version
+            // surfaced by failing the call.
+            RecoveryOutcome::Failed {
+                resource,
+                lease_id,
+                detail,
+            } => {
+                tracing::error!(
+                    ?resource,
+                    %lease_id,
+                    %detail,
+                    "stale DNS transaction could not be recovered; record kept for a later pass"
+                )
+            }
+            RecoveryOutcome::ExternalConflict { resource, lease_id } => {
+                tracing::error!(
+                    ?resource,
+                    %lease_id,
+                    "stale DNS transaction conflicts with external state; left untouched"
+                )
+            }
+            RecoveryOutcome::Busy { resource } => {
+                tracing::warn!(?resource, "stale DNS resource busy; left untouched")
+            }
+            _ => tracing::warn!("unrecognized DNS recovery outcome"),
         }
     }
 }
@@ -974,6 +1063,80 @@ mod tests {
                 .recover_stale()
                 .expect_err("corrupt journal must fail closed");
             assert!(matches!(err, osdns::Error::JournalCorrupt(_)));
+        }
+
+        /// osdns 0.2 does not migrate 0.1.x journal records: one leftover
+        /// record fails `recover_stale`, `abandon_journal` and `apply` alike,
+        /// so an upgraded agent would lose DNS integration entirely on exactly
+        /// the machines that crashed before upgrading, with no way out through
+        /// the osdns API.
+        #[test]
+        fn pre_upgrade_journal_record_is_discarded_instead_of_disabling_dns() {
+            let (manager, _fake, dir) = enforce_manager(full_caps());
+            let journal_dir = dir.path().join("journal");
+            std::fs::create_dir_all(&journal_dir).unwrap();
+            let legacy = journal_dir.join("pre-upgrade.json");
+            // osdns reads a `{ schema_version }` envelope before the record
+            // proper, so this is rejected exactly as a real 0.1.x record is.
+            std::fs::write(&legacy, br#"{"schema_version":1}"#).unwrap();
+
+            assert!(
+                matches!(
+                    manager.recover_stale(),
+                    Err(osdns::Error::UnsupportedJournalVersion { .. })
+                ),
+                "osdns itself must refuse the legacy record"
+            );
+
+            crate::system_dns::recover_stale(&manager)
+                .expect("a pre-upgrade record must not disable DNS integration");
+
+            assert!(!legacy.exists(), "the legacy record must be removed");
+            manager
+                .recover_stale()
+                .expect("osdns must be usable once the legacy record is gone");
+        }
+
+        /// A legacy record must not take healthy records down with it: osdns
+        /// aborts the whole read on the first bad file, so clearing has to
+        /// happen before the rest of the journal can be recovered at all.
+        #[test]
+        fn a_pre_upgrade_record_does_not_block_recovery_of_current_records() {
+            use osdns::testing::{CrashOutcome, FaultInjector, TxPoint, catch_crash};
+
+            let (manager, _fake, dir) = enforce_manager(full_caps());
+            let injector = FaultInjector::new();
+            injector.crash_at(TxPoint::AfterPrepared);
+            manager.install_fault_injector(injector.clone());
+            let outcome = catch_crash(|| manager.apply(&global_config()));
+            assert!(matches!(outcome, CrashOutcome::Crashed));
+            injector.clear();
+
+            let journal_dir = dir.path().join("journal");
+            let json_files = || {
+                std::fs::read_dir(&journal_dir)
+                    .map(|entries| {
+                        entries
+                            .flatten()
+                            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+                            .count()
+                    })
+                    .unwrap_or(0)
+            };
+            assert_eq!(json_files(), 1, "the crash should leave one live record");
+
+            let legacy = journal_dir.join("pre-upgrade.json");
+            std::fs::write(&legacy, br#"{"schema_version":1}"#).unwrap();
+            assert_eq!(json_files(), 2);
+
+            crate::system_dns::recover_stale(&manager)
+                .expect("recovery must proceed once the legacy record is cleared");
+
+            assert_eq!(
+                json_files(),
+                0,
+                "both the legacy record and the recovered record should be gone"
+            );
         }
 
         const MAGIC_IP: Ipv4Addr = Ipv4Addr::new(100, 100, 100, 53);


### PR DESCRIPTION
osdns 0.2.0 is released and fixes the vanished-interface bug from orielhaim/osdns#2. It also changes two contracts that need handling here, so this is a bump plus a migration rather than a version bump alone.

## What 0.2.0 changes for us

A resource that ceased to exist is now reported as `RecoveryOutcome::Gone` rather than a `Platform` error, which is exactly what #21 worked around downstream with a `NoSuchLink` string match. **#21 becomes obsolete if this lands** and should be closed rather than merged. Nothing from it needs porting, because the error path it handled no longer exists.

`recover_stale()` no longer returns `Err` for a failing record. It returns `Ok` with `RecoveryOutcome::Failed` in the vec, and the changelog states that callers must inspect outcomes. Our code had a `_ =>` catch-all logging at debug, so a genuine recovery failure would have been reported as success and dropped silently. Every variant is now matched explicitly, with `Failed` at error level.

## The migration, and why it is not optional

The 0.2.0 changelog says 0.1.x state is intentionally not migrated and must be cleared before upgrading. Verified against the published crate with a two-crate reproduction, producer pinned to `=0.1.3` and consumer to `0.2.0`, sharing a `state_dir`:

```
recover_stale  : FAILED unsupported journal schema version 1 in <path> (supported: 3)
abandon_journal: FAILED unsupported journal schema version 1 in <path> (supported: 3)
apply          : FAILED unsupported journal schema version 1 in <path> (supported: 3)
```

So it is not only recovery: `apply()` fails too, and `abandon_journal` cannot serve as the escape hatch because it fails identically. Without a migration step, upgrading leaves DNS integration permanently dead on any machine that crashed before the upgrade, remediable only by deleting a file by hand. That is precisely the population that will have a record, since a leftover record is what a crash produces.

Recovery therefore discards the specific file named in the typed `UnsupportedJournalVersion` error and warns that the DNS settings it described are not restored. It removes only files osdns itself declares incompatible, rather than wiping a state directory we do not own.

## Verification

`fmt`, `clippy --all-targets --all-features -D warnings`, and 352 tests pass.

Both new tests were confirmed to fail without the change, not merely to pass with it: disabling the clearing path takes them from 2 passed to 2 failed. The second test is the one that matters, because osdns aborts the whole journal read on the first bad file, so a single legacy record otherwise blocks recovery of unrelated healthy records.

Not covered: these exercise the fake backend, so the migration is proven against the journal contract rather than against systemd-resolved on a live host.