### PR TITLE
fix(dns): discard a pre-upgrade journal record instead of losing DNS

### DIFF
--- a/crates/tunnet-agent/src/system_dns.rs
+++ b/crates/tunnet-agent/src/system_dns.rs
@@ -323,9 +323,35 @@ pub fn desired_config(
 /// safely recover stale ownership from a crashed daemon process.
 ///
 /// Never guesses ownership: per-resource outcomes are logged and left as
-/// osdns reported them. Enumeration, schema, and integrity errors fail
-/// closed. Per-resource failures do not abort recovery of unrelated records.
+/// osdns reported them. Integrity errors fail closed. Per-resource failures do
+/// not abort recovery of unrelated records.
+///
+/// The one exception is a pre-upgrade journal record. osdns 0.2 does not
+/// migrate 0.1.x records and refuses to read them, which fails `recover_stale`,
+/// `abandon_journal` and `apply` alike, so the agent would run with DNS
+/// integration off on every start until someone deleted the file. Nothing is
+/// reinterpreted by removing it: no osdns version will ever act on that record,
+/// so the choice is between discarding an unreadable file and losing DNS.
 fn recover_stale(manager: &DnsManager) -> osdns::Result<()> {
+    for _ in 0..MAX_LEGACY_JOURNAL_CLEARS {
+        let Err(error) = manager.recover_stale() else {
+            break;
+        };
+        let osdns::Error::UnsupportedJournalVersion { path, found, .. } = &error else {
+            break;
+        };
+        tracing::warn!(
+            path = %path.display(),
+            found,
+            "discarding a pre-upgrade osdns journal record; the DNS settings it \
+             described are not restored"
+        );
+        if let Err(io) = std::fs::remove_file(path) {
+            tracing::error!(path = %path.display(), error = %io, "could not remove it");
+            break;
+        }
+    }
+
     match manager.recover_stale() {
         Ok(outcomes) => {
             for outcome in outcomes {
@@ -393,6 +419,11 @@ fn recover_stale(manager: &DnsManager) -> osdns::Result<()> {
         }
     }
 }
+
+/// Bound on pre-upgrade records discarded per start. Each pass removes exactly
+/// one named file, so this only caps the retry if removal stops making
+/// progress.
+const MAX_LEGACY_JOURNAL_CLEARS: usize = 64;
 
 fn log_apply_failure(e: &osdns::Error) {
     match e {
@@ -1014,18 +1045,22 @@ mod tests {
         }
 
         #[test]
-        fn legacy_journal_schema_fails_closed_without_reinterpretation() {
+        fn legacy_journal_is_never_reinterpreted_but_does_not_disable_dns() {
             let (manager, _fake, dir) = enforce_manager(full_caps());
             let journal_dir = dir.path().join("journal");
             std::fs::create_dir_all(&journal_dir).unwrap();
+            let legacy = journal_dir.join("v1.json");
             std::fs::write(
-                journal_dir.join("v1.json"),
+                &legacy,
                 br#"{"schema_version":1,"owner":"io.tunnet.agent"}"#,
             )
             .unwrap();
+
+            // osdns still refuses to read it, and that must not change: the
+            // record is never parsed, trusted, or acted on.
             let err = manager
                 .recover_stale()
-                .expect_err("0.1.x journals must fail closed");
+                .expect_err("0.1.x journals must fail closed inside osdns");
             assert!(
                 matches!(
                     err,
@@ -1037,10 +1072,50 @@ mod tests {
                 ),
                 "got {err:?}"
             );
-            assert!(
-                DnsController::wrap(manager).is_err(),
-                "controller must not start on a v1 journal"
-            );
+
+            // The agent discards the unreadable file rather than running with
+            // DNS integration off on every start until a human intervenes.
+            let controller = DnsController::wrap(manager)
+                .expect("a pre-upgrade record must not disable DNS integration");
+            drop(controller);
+            assert!(!legacy.exists(), "the unreadable record should be gone");
+        }
+
+        /// osdns aborts the whole journal read on the first unreadable file, so
+        /// a single pre-upgrade record otherwise blocks recovery of unrelated
+        /// current-schema records too.
+        #[test]
+        fn legacy_journal_does_not_block_recovery_of_current_records() {
+            use osdns::testing::{CrashOutcome, FaultInjector, TxPoint, catch_crash};
+
+            let (manager, _fake, dir) = enforce_manager(full_caps());
+            let injector = FaultInjector::new();
+            injector.crash_at(TxPoint::AfterPrepared);
+            manager.install_fault_injector(injector.clone());
+            let outcome = catch_crash(|| manager.apply(&global_config()));
+            assert!(matches!(outcome, CrashOutcome::Crashed));
+            injector.clear();
+
+            let journal_dir = dir.path().join("journal");
+            let json_count = || {
+                std::fs::read_dir(&journal_dir)
+                    .map(|e| {
+                        e.flatten()
+                            .filter(|f| f.path().extension().is_some_and(|x| x == "json"))
+                            .count()
+                    })
+                    .unwrap_or(0)
+            };
+            assert_eq!(json_count(), 1, "the crash should leave one live record");
+            std::fs::write(
+                journal_dir.join("v1.json"),
+                br#"{"schema_version":1,"owner":"io.tunnet.agent"}"#,
+            )
+            .unwrap();
+
+            super::super::recover_stale(&manager)
+                .expect("recovery must proceed once the unreadable record is cleared");
+            assert_eq!(json_count(), 0, "both records should be resolved");
         }
 
         #[test]


### PR DESCRIPTION
Reopens one narrow piece of the closed #25, on its own this time, because it changes a contract you asserted deliberately in `eb26a6f`. Easy to reject if you disagree; the tradeoff is below.

## What happens today

osdns 0.2 does not migrate 0.1.x journal records. Verified against the published crate with a two-crate reproduction (producer pinned `=0.1.3`, consumer `0.2.0`, shared `state_dir`):

```
recover_stale  : FAILED unsupported journal schema version 1 in <path> (supported: 3)
abandon_journal: FAILED unsupported journal schema version 1 in <path> (supported: 3)
apply          : FAILED unsupported journal schema version 1 in <path> (supported: 3)
```

So `DnsController::create` fails, `runtime.rs` logs `osdns DNS integration unavailable` and continues with `None`. The agent keeps running and looks healthy, DNS integration is off, and it stays off on every subsequent start until a human deletes the file. The machines holding such a record are the ones that crashed before upgrading, which is the same population that hit the original vanished-interface bug.

## Why I think discarding is right

Your test name is `..._without_reinterpretation`, and I agree with that principle: an unknown record must never be parsed, trusted or acted on. This does not reinterpret it. osdns will not read a v1 record under any circumstances, so it cannot be used to restore anything, and keeping it preserves no capability at all. It only preserves the file.

The real choice is between discarding an unreadable file and losing DNS integration. Removal is limited to the exact path osdns names in its typed `UnsupportedJournalVersion` error, so nothing else in a state directory we do not own is touched, and it warns that the DNS settings the record described are not restored. Every other error still fails closed exactly as before.

## The test change

`legacy_journal_schema_fails_closed_without_reinterpretation` asserted `DnsController::wrap(manager).is_err()`, which this contradicts, so I updated it rather than deleting it. It still asserts osdns itself refuses the record, which remains true and is the part worth protecting; it now asserts the controller starts anyway, and that the file is gone.

A second test covers what motivated the retry bound: osdns aborts the whole journal read on the first unreadable file, so one legacy record otherwise blocks recovery of unrelated current-schema records.

Both were confirmed to fail without the change, not merely to pass with it: disabling the clearing path takes them from 2 passed to 2 failed.

## If you would rather keep failing closed

Then the failure should at least be visible without reading startup logs. `DnsStatusInfo` would be the place, but it is built in `tunnet-core` from `LocalApiState` while the controller lives in `tunnet-agent`, so that is cross-crate plumbing rather than a small change. Happy to do it that way instead if you prefer the current contract.

`fmt`, `clippy --all-targets --all-features -D warnings`, 388 tests.