### PR TITLE
fix(direct): serve every post-auth request, not just the first

### DIFF
--- a/crates/tunnet-agent/src/cmds_direct.rs
+++ b/crates/tunnet-agent/src/cmds_direct.rs
@@ -132,12 +132,53 @@ pub async fn try_handle_post_auth(
     let policy = SealPolicy::from_env_and_flag(false);
     let remote_id = format!("{}", conn.remote_id());
 
-    let (mut send, mut recv) =
+    // Serve every request the peer sends on this connection, not just the
+    // first. Joining is two round trips (`join_prepare` then `join_commit`)
+    // over one authenticated connection, so answering once and letting the
+    // caller close the connection strands the peer waiting for the second
+    // response.
+    let mut served = 0usize;
+    loop {
         match tokio::time::timeout(std::time::Duration::from_secs(5), conn.accept_bi()).await {
-            Ok(Ok(streams)) => streams,
+            Ok(Ok(streams)) => {
+                serve_post_auth_request(
+                    streams, &paths, state_dir, docs, network_id, auth, routes, acl, &remote_id,
+                    policy,
+                )
+                .await?;
+                served += 1;
+            }
+            // The peer finished and hung up. Only the first request is
+            // mandatory; after that a closed connection is the normal end.
+            Ok(Err(e)) if served > 0 => {
+                tracing::debug!(?e, served, "post-auth peer closed the connection");
+                return Ok(());
+            }
+            Err(_) if served > 0 => {
+                tracing::debug!(served, "post-auth peer went idle");
+                return Ok(());
+            }
             Ok(Err(e)) => anyhow::bail!("accept post-auth stream: {e}"),
             Err(_) => anyhow::bail!("timed out waiting for post-auth stream from peer"),
-        };
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_post_auth_request(
+    streams: (iroh::endpoint::SendStream, iroh::endpoint::RecvStream),
+    paths: &StatePaths,
+    state_dir: &std::path::Path,
+    docs: Option<&DocsMembership>,
+    network_id: uuid::Uuid,
+    auth: &tunnet_core::direct::auth::AuthCache,
+    routes: &tunnet_core::RoutingTable,
+    acl: &tunnet_core::AclEngine,
+    remote_id: &str,
+    policy: SealPolicy,
+) -> anyhow::Result<()> {
+    let (mut send, mut recv) = streams;
+    let remote_id = remote_id.to_string();
 
     let Ok((_identity, persisted, _)) = load_agent(&paths, policy) else {
         write_post_auth_response(&mut send, &post_auth_deny("coordinator_state_unavailable"))


### PR DESCRIPTION
**Joining a Direct network has been impossible since #24 merged, on every platform.** Found while testing #13 on a real phone; it is not Android-specific.

## What happens

The client performs two round trips over one authenticated connection:

```rust
run_auth_client(&conn, ...)                     // ok
rpc_send_recv(&conn, {"type": "join_prepare"})  // ok
rpc_send_recv(&conn, {"type": "join_commit"})   // fails
```

The server answers one post-auth request and hangs up:

```rust
try_handle_post_auth(&conn, ...).await   // accepts ONE bi stream, replies
conn.close(0u32.into(), b"done");
```

So `join_commit` reads from a closed connection and the joining peer fails with `read rpc response`. No membership is written.

The two-step handshake arrived with #24: `join_prepare` and `join_commit` appear nowhere before that merge, while this side kept the one-shot shape it had when joining was a single `join_request`. Only half the migration landed.

## Why it was invisible

The coordinator logs **nothing at all** for a failed join. Both the auth handshake and `join_prepare` succeed, and those paths are silent; `conn.close` is normal. The only externally visible symptom is on the joining side, and the member list simply never grows. I spent a while assuming the connection was not arriving before realising a fully successful join and this failure produce identical coordinator logs.

## The fix

Serve requests in a loop until the peer hangs up. A closed or idle connection is a normal end once at least one request has been served, but a connection that authenticates and then sends nothing still fails as before, so a stalled peer is not silently ignored.

## Verification

Real device, not a unit test. Before, every join attempt from a Pixel 8a failed at `join_commit`. After, the join completes and the phone appears in the member list:

```
10.85.70.64      tunnet-node  coordinator=True   active
10.85.70.130     Pixel 8a     coordinator=False  active
```

`tunnet status` on the coordinator reports `peers 1 online / 1 total`, and traffic flows: a TCP request from the phone to the coordinator's mesh address returns `HTTP/1.1 200 OK`.

`fmt`, `clippy --all-targets --all-features -D warnings`, 386 tests.

I have not added a regression test. The gap is a protocol-level one between two agents over a real connection, and the existing suite has no harness for that; a unit test on this function would only restate the loop. Worth deciding whether a two-agent integration test is wanted, because this class of bug is otherwise invisible until someone joins from a second machine.